### PR TITLE
Add paycycle features

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -40,7 +40,7 @@ def generate_cyclical_features(df: pd.DataFrame, window_size: int = 7) -> pd.Dat
     # Prepare full column structure regardless of input size
     cols = ["start_date", "store_item", "store", "item"]
     for i in range(1, window_size + 1):
-        for feature in ["dayofweek", "weekofmonth", "monthofyear"]:
+        for feature in ["dayofweek", "weekofmonth", "monthofyear", "paycycle"]:
             for trig in ["sin", "cos"]:
                 cols.append(f"{feature}_{trig}_{i}")
 
@@ -57,6 +57,23 @@ def generate_cyclical_features(df: pd.DataFrame, window_size: int = 7) -> pd.Dat
     df["monthofyear"] = df["date"].dt.month
     df["monthofyear_sin"] = np.sin(2 * np.pi * df["monthofyear"] / 12)
     df["monthofyear_cos"] = np.cos(2 * np.pi * df["monthofyear"] / 12)
+
+    # --- Pay cycle features ---
+    def _pay_cycle_ratio(d: pd.Timestamp) -> float:
+        month_end_day = (d + pd.offsets.MonthEnd(0)).day
+        if d.day >= 15:
+            last_pay = d.replace(day=15)
+            next_pay = d.replace(day=month_end_day)
+        else:
+            prev_month_end = d - pd.offsets.MonthEnd(1)
+            last_pay = prev_month_end
+            next_pay = d.replace(day=15)
+        cycle_len = (next_pay - last_pay).days
+        return ((d - last_pay).days / cycle_len) if cycle_len else 0.0
+
+    df["paycycle_ratio"] = df["date"].apply(_pay_cycle_ratio)
+    df["paycycle_sin"] = np.sin(2 * np.pi * df["paycycle_ratio"])
+    df["paycycle_cos"] = np.cos(2 * np.pi * df["paycycle_ratio"])
 
     windows = generate_aligned_windows(df, window_size)
     results = []
@@ -79,11 +96,21 @@ def generate_cyclical_features(df: pd.DataFrame, window_size: int = 7) -> pd.Dat
             for i in range(window_size):
                 if i < len(window_df):
                     r = window_df.iloc[i]
-                    for f in ["dayofweek", "weekofmonth", "monthofyear"]:
+                    for f in [
+                        "dayofweek",
+                        "weekofmonth",
+                        "monthofyear",
+                        "paycycle",
+                    ]:
                         for t in ["sin", "cos"]:
                             row[f"{f}_{t}_{i+1}"] = r[f"{f}_{t}"]
                 else:
-                    for f in ["dayofweek", "weekofmonth", "monthofyear"]:
+                    for f in [
+                        "dayofweek",
+                        "weekofmonth",
+                        "monthofyear",
+                        "paycycle",
+                    ]:
                         for t in ["sin", "cos"]:
                             row[f"{f}_{t}_{i+1}"] = 0.0
 

--- a/tests/1_test_utils.py
+++ b/tests/1_test_utils.py
@@ -320,10 +320,18 @@ def test_generate_cyclical_features_empty_df():
         "dayofweek_cos_1",
         "weekofmonth_sin_1",
         "weekofmonth_cos_1",
+        "monthofyear_sin_1",
+        "monthofyear_cos_1",
+        "paycycle_sin_1",
+        "paycycle_cos_1",
         "dayofweek_sin_2",
         "dayofweek_cos_2",
         "weekofmonth_sin_2",
         "weekofmonth_cos_2",
+        "monthofyear_sin_2",
+        "monthofyear_cos_2",
+        "paycycle_sin_2",
+        "paycycle_cos_2",
     ]
     assert list(result.columns) == expected_columns
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,7 +158,7 @@ def test_add_next_window_targets_column_integrity():
     result = add_next_window_targets(merged_df, window_size=window_size)
 
     y_cols = [col for col in result.columns if col.startswith("y_")]
-    assert len(y_cols) == 2 + 2 * 2 * 2  # 2 sales + 2 cyc_feats × 2 trigs × 2 days
+    assert len(y_cols) == 2 + 3 * 2 * 2  # 2 sales + 3 cyc_feats × 2 trigs × 2 days
     assert all(col in result.columns for col in y_cols)
 
 


### PR DESCRIPTION
## Summary
- encode biweekly public sector pay cycle in `generate_cyclical_features`
- update expected cyclical columns in tests
- fix next-window target test to consider all cyclic features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6842f4dcae64832fa9ffd9d1d9c3bc8f