### PR TITLE
Fix imports for utils tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,8 @@
 import pandas as pd
 from datetime import datetime
 import numpy as np
-from src.utils import (     
-    generate_sales_features,
+from src.utils_1 import (
+    generate_nonoverlap_window_features,
     generate_cyclical_features,
     add_next_window_targets,
 )


### PR DESCRIPTION
## Summary
- use the updated utils module for test utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6843040f09e4832fb705f031f71fe7f3