### PR TITLE
Add helper for feature column names

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -625,3 +625,23 @@ def compute_spectral_biclustering_row_col_cv_scores(
             )
 
     return pd.DataFrame(results)
+
+
+def build_feature_and_label_cols(window_size: int) -> tuple[list[str], list[str]]:
+    """Return feature and label column names for a given window size."""
+    cyclical_features = [
+        f"{feat}_{trig}_{i}"
+        for feat in ["dayofweek", "weekofmonth", "monthofyear", "paycycle"]
+        for trig in ["sin", "cos"]
+        for i in range(1, window_size + 1)
+    ]
+
+    sales_features = [
+        f"{name}_{i}"
+        for name in ["sales_day", "store_med_day", "item_med_day"]
+        for i in range(1, window_size + 1)
+    ]
+
+    feature_cols = sales_features + cyclical_features
+    label_cols = [f"y_{c}" for c in feature_cols]
+    return feature_cols, label_cols

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ from src.utils import (
     generate_nonoverlap_window_features,
     generate_cyclical_features,
     add_next_window_targets,
+    build_feature_and_label_cols,
 )
 
 
@@ -188,3 +189,13 @@ def test_add_next_window_targets_drop_nan_rows():
 
     # Check all y_ columns in cleaned data are fully non-null
     assert cleaned[y_cols].notna().all().all()
+
+
+def test_build_feature_and_label_cols():
+    feature_cols, label_cols = build_feature_and_label_cols(window_size=2)
+    assert feature_cols[0] == 'sales_day_1'
+    assert feature_cols[-1] == 'paycycle_cos_2'
+    assert len(feature_cols) == 6 + 16
+    assert label_cols[0] == 'y_sales_day_1'
+    assert label_cols[-1] == 'y_paycycle_cos_2'
+    assert len(label_cols) == len(feature_cols)


### PR DESCRIPTION
## Summary
- add `build_feature_and_label_cols` helper in utils
- test new helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch' / 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684309f0f6c8832f8a3ca5c187475eff