### PR TITLE
Add clustering helper

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -526,6 +526,45 @@ def compute_spectral_biclustering_row_cv_scores(
     return pd.DataFrame(results)
 
 
+def generate_store_item_clusters(
+    pivot_clean: pd.DataFrame,
+    n_clusters: int,
+    cluster_algo,
+) -> pd.DataFrame:
+    """Cluster store/item series and return labels.
+
+    Parameters
+    ----------
+    pivot_clean : pd.DataFrame
+        Pivot table where each row corresponds to a ``store_item`` and
+        columns are the time series values.
+    n_clusters : int
+        Desired number of clusters to fit.
+    cluster_algo : type | object
+        Scikit‑learn clustering estimator class or instance.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with ``store_item`` and ``clusterId`` columns.
+    """
+
+    # Instantiate algorithm if a class is provided
+    if isinstance(cluster_algo, type):
+        model = cluster_algo(n_clusters=n_clusters)
+    else:
+        model = cluster_algo
+        if hasattr(model, "set_params"):
+            model.set_params(n_clusters=n_clusters)
+
+    labels = model.fit_predict(pivot_clean.values)
+
+    return pd.DataFrame({
+        "store_item": pivot_clean.index,
+        "clusterId": labels,
+    })
+
+
 def compute_spectral_clustering_cv_scores(
     data,
     *,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from src.utils import (
     generate_cyclical_features,
     add_next_window_targets,
     build_feature_and_label_cols,
+    generate_store_item_clusters,
 )
 
 
@@ -247,3 +248,25 @@ def test_build_feature_and_label_cols():
     assert label_cols[24] == "y_season_cos_1"
     assert label_cols[25] == "y_season_cos_2"
     assert len(label_cols) == len(feature_cols)
+
+
+def test_generate_store_item_clusters_basic():
+    pivot = pd.DataFrame(
+        [
+            [1, 2],
+            [2, 1],
+            [10, 10],
+            [11, 11],
+        ],
+        index=["s1_i1", "s1_i2", "s2_i1", "s2_i2"],
+    )
+
+    from sklearn.cluster import KMeans
+
+    result = generate_store_item_clusters(
+        pivot, n_clusters=2, cluster_algo=KMeans(random_state=42, n_init="auto")
+    )
+
+    assert list(result.columns) == ["store_item", "clusterId"]
+    assert len(result) == 4
+    assert set(result["clusterId"]).issubset({0, 1})


### PR DESCRIPTION
## Summary
- add `generate_store_item_clusters` helper to cluster pivot tables
- test the new function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68448c8f0904832fae69161ad2d01abb