### PR TITLE
Fix mapping of cluster columns

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -222,6 +222,9 @@ def generate_sales_features(
             )
         else:  # DataFrame
             cluster_df = cluster_map.copy()
+            # normalise common column names
+            if "clusterId" in cluster_df.columns and "cluster_id" not in cluster_df.columns:
+                cluster_df = cluster_df.rename(columns={"clusterId": "cluster_id"})
 
         cluster_df["store_item"] = cluster_df["store_item"].astype(str)
 


### PR DESCRIPTION
## Summary
- handle `clusterId` column from `generate_store_item_clusters` when building sales features

## Testing
- `pytest tests/test_utils.py::test_generate_sales_features_with_clusters -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6844bd6698c4832fa5af0889083e3961