### PR TITLE
Add Poetry configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ This repository contains code and data for the Favorita Grocery Sales Forecastin
 * numpy
 * matplotlib
 * scikit-learn
+
+## Using Poetry
+
+This project uses [Poetry](https://python-poetry.org/) for dependency management. To install the dependencies, run:
+
+```bash
+poetry install
+```
+
+This will create a virtual environment and install the packages listed in `pyproject.toml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "favorita-grocery-sales"
+version = "0.1.0"
+description = "Favorita Grocery Sales Forecasting"
+authors = ["Unknown <unknown@example.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.9,<4.0"
+pandas = ">=2.0.0"
+numpy = ">=1.24.0"
+scikit-learn = "*"
+
+[tool.poetry.group.dev.dependencies]
+pytest = ">=8.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.5.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- add pyproject.toml with Poetry metadata and dependencies
- document Poetry usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684b24b3b4fc832fb8e169a448f3585c