### PR TITLE
Add bioinformatics benchmark curator skill with renderer, validator, schema, and tests

### DIFF
--- a/bioinformatics-benchmark-curator/SKILL.md
+++ b/bioinformatics-benchmark-curator/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: bioinformatics-benchmark-curator
+description: Curate, normalize, validate, and generate awesome-list style benchmark pages for bioinformatics (or adjacent scientific ML domains). Use when building or maintaining benchmark catalogs from papers/repos, enforcing a consistent metadata schema, checking links, and rendering grouped Markdown sections like awesome-bioinformatics-benchmarks.
+---
+
+# Bioinformatics Benchmark Curator
+
+## Overview
+Use this skill to implement or maintain a benchmark curation agent that turns structured benchmark metadata into a high-quality awesome-list style README.
+Prefer scripted generation/validation for deterministic formatting and quality checks.
+
+## Quick Start Workflow
+1. Collect benchmark items into `assets/sample_benchmarks.json` schema (or your own JSON file).
+2. Validate data quality and links with:
+   - `python scripts/validate_benchmarks.py --input <path>.json`
+3. Render Markdown page with:
+   - `python scripts/render_awesome_readme.py --input <path>.json --output README.generated.md`
+4. Review grouped sections and edit taxonomy in `references/taxonomy.md` if needed.
+
+## Required Entry Schema
+Each benchmark item should include:
+- `name`: Human-readable benchmark name.
+- `task_category`: Top-level grouping (e.g., genomics, protein-structure, single-cell).
+- `summary`: One-sentence purpose.
+- `paper_url`: Canonical publication URL.
+- `code_url`: Repository or project URL.
+- `modality`: Data modality (sequence, structure, expression, multimodal).
+- `license`: Dataset/benchmark license (or `unknown`).
+- `year`: Integer release/publication year.
+
+Optional fields:
+- `dataset_url`, `leaderboard_url`, `metrics`, `notes`, `tags`.
+
+See `references/entry-schema.md` for full details and examples.
+
+## Curation Rules
+- Use canonical URLs (`https://...`) and prefer stable landing pages.
+- Keep summaries concise (one sentence; avoid marketing language).
+- Group by `task_category`, then sort by `year` descending and `name` ascending.
+- Reject duplicate names (case-insensitive) during validation.
+- Preserve neutral wording and cite benchmark scope/limitations in `notes` if relevant.
+
+## Resource Usage Guide
+- Read `references/taxonomy.md` when deciding task groups and naming conventions.
+- Use `scripts/validate_benchmarks.py` before rendering to catch missing fields and malformed links.
+- Use `scripts/render_awesome_readme.py` to regenerate markdown after edits.
+- Use `assets/awesome_readme_template.md` as the output structure baseline.
+
+## Example Commands
+```bash
+python scripts/validate_benchmarks.py --input assets/sample_benchmarks.json
+python scripts/render_awesome_readme.py \
+  --input assets/sample_benchmarks.json \
+  --output assets/sample_README.generated.md
+```

--- a/bioinformatics-benchmark-curator/assets/awesome_readme_template.md
+++ b/bioinformatics-benchmark-curator/assets/awesome_readme_template.md
@@ -1,0 +1,9 @@
+# Awesome Bioinformatics Benchmarks
+
+Curated benchmark resources for bioinformatics and computational biology.
+
+## Contents
+<!-- generated toc -->
+
+## Benchmarks by Category
+<!-- generated sections -->

--- a/bioinformatics-benchmark-curator/assets/sample_README.generated.md
+++ b/bioinformatics-benchmark-curator/assets/sample_README.generated.md
@@ -1,0 +1,15 @@
+# Awesome Bioinformatics Benchmarks
+
+Curated benchmark resources for bioinformatics and computational biology.
+
+## Contents
+- [genomics](#genomics)
+- [multimodal-biology](#multimodal-biology)
+
+## Benchmarks by Category
+
+### genomics
+- **Genome Understanding Evaluation (GUE)** (2022): Benchmark suite for genomic sequence understanding tasks. — [paper](https://arxiv.org/abs/2206.11200) | [code](https://github.com/ZhiGroup/GUE)
+
+### multimodal-biology
+- **OpenBioMed-Bench** (2024): Evaluate multimodal biomedical representation learning across tasks. — [paper](https://arxiv.org/abs/2405.00001) | [code](https://github.com/PharMolix/OpenBioMed)

--- a/bioinformatics-benchmark-curator/assets/sample_benchmarks.json
+++ b/bioinformatics-benchmark-curator/assets/sample_benchmarks.json
@@ -1,0 +1,28 @@
+{
+  "title": "Awesome Bioinformatics Benchmarks",
+  "description": "Curated benchmark resources for bioinformatics and computational biology.",
+  "items": [
+    {
+      "name": "Genome Understanding Evaluation (GUE)",
+      "task_category": "genomics",
+      "summary": "Benchmark suite for genomic sequence understanding tasks.",
+      "paper_url": "https://arxiv.org/abs/2206.11200",
+      "code_url": "https://github.com/ZhiGroup/GUE",
+      "modality": "sequence",
+      "license": "MIT",
+      "year": 2022,
+      "tags": ["foundation-models", "sequence"]
+    },
+    {
+      "name": "OpenBioMed-Bench",
+      "task_category": "multimodal-biology",
+      "summary": "Evaluate multimodal biomedical representation learning across tasks.",
+      "paper_url": "https://arxiv.org/abs/2405.00001",
+      "code_url": "https://github.com/PharMolix/OpenBioMed",
+      "modality": "multimodal",
+      "license": "Apache-2.0",
+      "year": 2024,
+      "metrics": ["accuracy", "F1"]
+    }
+  ]
+}

--- a/bioinformatics-benchmark-curator/references/entry-schema.md
+++ b/bioinformatics-benchmark-curator/references/entry-schema.md
@@ -1,0 +1,37 @@
+# Benchmark Entry Schema
+
+## Required Fields
+- `name` (string): Benchmark title.
+- `task_category` (string): Section grouping key.
+- `summary` (string): One-sentence description.
+- `paper_url` (string): Publication/preprint URL.
+- `code_url` (string): Source code URL.
+- `modality` (string): Data modality.
+- `license` (string): Distribution license or `unknown`.
+- `year` (integer): Publication year.
+
+## Optional Fields
+- `dataset_url` (string)
+- `leaderboard_url` (string)
+- `metrics` (array of strings)
+- `tags` (array of strings)
+- `notes` (string)
+
+## Example Entry
+```json
+{
+  "name": "Genomics Long-Range Benchmark",
+  "task_category": "genomics",
+  "summary": "Evaluate sequence models on long-context regulatory prediction tasks.",
+  "paper_url": "https://arxiv.org/abs/2401.00001",
+  "code_url": "https://github.com/example/glrb",
+  "dataset_url": "https://zenodo.org/records/1234567",
+  "leaderboard_url": "https://paperswithcode.com/sota/example",
+  "modality": "sequence",
+  "license": "CC-BY-4.0",
+  "metrics": ["AUROC", "AUPRC"],
+  "tags": ["long-context", "regulatory"],
+  "notes": "Contains train/dev/test splits for human and mouse.",
+  "year": 2024
+}
+```

--- a/bioinformatics-benchmark-curator/references/taxonomy.md
+++ b/bioinformatics-benchmark-curator/references/taxonomy.md
@@ -1,0 +1,21 @@
+# Recommended Taxonomy
+
+Use stable and broad `task_category` values:
+- `genomics`
+- `transcriptomics`
+- `single-cell`
+- `protein-structure`
+- `protein-function`
+- `multimodal-biology`
+- `clinical-omics`
+- `other`
+
+## Naming Guidance
+- Prefer lowercase kebab-case for category keys.
+- Keep category set small; use `tags` for finer granularity.
+- Avoid overlapping categories unless the benchmark is genuinely cross-domain.
+
+## Sort Convention
+Within each category:
+1. `year` descending
+2. `name` ascending

--- a/bioinformatics-benchmark-curator/scripts/render_awesome_readme.py
+++ b/bioinformatics-benchmark-curator/scripts/render_awesome_readme.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Render an awesome-list style benchmark README from JSON metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def slugify(text: str) -> str:
+    return text.strip().lower().replace(" ", "-")
+
+
+def render_item(item: dict) -> str:
+    links = [f"[paper]({item['paper_url']})", f"[code]({item['code_url']})"]
+    if item.get("dataset_url"):
+        links.append(f"[dataset]({item['dataset_url']})")
+    if item.get("leaderboard_url"):
+        links.append(f"[leaderboard]({item['leaderboard_url']})")
+
+    tail = f" — {' | '.join(links)}"
+    return f"- **{item['name']}** ({item['year']}): {item['summary']}{tail}"
+
+
+def render_markdown(data: dict) -> str:
+    title = data.get("title", "Awesome Bioinformatics Benchmarks")
+    description = data.get("description", "Curated benchmark resources.")
+    items = data.get("items", [])
+
+    grouped = defaultdict(list)
+    for item in items:
+        grouped[item["task_category"]].append(item)
+
+    for category_items in grouped.values():
+        category_items.sort(key=lambda x: (-x["year"], x["name"].lower()))
+
+    categories = sorted(grouped.keys())
+    lines: list[str] = [f"# {title}", "", description, "", "## Contents"]
+    for category in categories:
+        lines.append(f"- [{category}](#{slugify(category)})")
+
+    lines.extend(["", "## Benchmarks by Category", ""])
+    for category in categories:
+        lines.append(f"### {category}")
+        for item in grouped[category]:
+            lines.append(render_item(item))
+        lines.append("")
+
+    return "\n".join(lines).strip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="Path to benchmark JSON")
+    parser.add_argument("--output", required=True, type=Path, help="Output markdown path")
+    args = parser.parse_args()
+
+    data = load_json(args.input)
+    output = render_markdown(data)
+    args.output.write_text(output, encoding="utf-8")
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bioinformatics-benchmark-curator/scripts/validate_benchmarks.py
+++ b/bioinformatics-benchmark-curator/scripts/validate_benchmarks.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Validate benchmark entries for awesome-list style generation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REQUIRED_FIELDS = {
+    "name": str,
+    "task_category": str,
+    "summary": str,
+    "paper_url": str,
+    "code_url": str,
+    "modality": str,
+    "license": str,
+    "year": int,
+}
+URL_FIELDS = {"paper_url", "code_url", "dataset_url", "leaderboard_url"}
+URL_RE = re.compile(r"^https?://")
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def validate(data: dict) -> list[str]:
+    errors: list[str] = []
+    items = data.get("items")
+    if not isinstance(items, list):
+        return ["top-level 'items' must be a list"]
+
+    seen_names: set[str] = set()
+    current_year = datetime.now().year + 1
+    for i, item in enumerate(items):
+        if not isinstance(item, dict):
+            errors.append(f"items[{i}] must be an object")
+            continue
+
+        for field, expected_type in REQUIRED_FIELDS.items():
+            if field not in item:
+                errors.append(f"items[{i}] missing required field: {field}")
+                continue
+            if not isinstance(item[field], expected_type):
+                errors.append(
+                    f"items[{i}].{field} must be {expected_type.__name__}, got {type(item[field]).__name__}"
+                )
+
+        name = str(item.get("name", "")).strip().lower()
+        if name:
+            if name in seen_names:
+                errors.append(f"items[{i}] duplicate name: {item.get('name')}")
+            seen_names.add(name)
+
+        year = item.get("year")
+        if isinstance(year, int) and (year < 1990 or year > current_year):
+            errors.append(f"items[{i}].year out of range: {year}")
+
+        for url_field in URL_FIELDS:
+            if url_field in item:
+                value = item.get(url_field)
+                if not isinstance(value, str) or not URL_RE.match(value):
+                    errors.append(f"items[{i}].{url_field} must start with http:// or https://")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="Path to benchmark JSON")
+    args = parser.parse_args()
+
+    data = load_json(args.input)
+    errors = validate(data)
+
+    if errors:
+        print("Validation failed:")
+        for err in errors:
+            print(f"- {err}")
+        return 1
+
+    print("Validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_bioinformatics_benchmark_curator_scripts.py
+++ b/tests/test_bioinformatics_benchmark_curator_scripts.py
@@ -1,0 +1,79 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = ROOT / "bioinformatics-benchmark-curator" / "scripts"
+ASSETS_DIR = ROOT / "bioinformatics-benchmark-curator" / "assets"
+
+
+def run(cmd):
+    return subprocess.run(cmd, text=True, capture_output=True, check=False)
+
+
+def test_validate_sample_benchmarks_passes():
+    result = run(
+        [
+            sys.executable,
+            str(SCRIPT_DIR / "validate_benchmarks.py"),
+            "--input",
+            str(ASSETS_DIR / "sample_benchmarks.json"),
+        ]
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Validation passed" in result.stdout
+
+
+def test_render_generates_markdown(tmp_path):
+    out = tmp_path / "README.generated.md"
+    result = run(
+        [
+            sys.executable,
+            str(SCRIPT_DIR / "render_awesome_readme.py"),
+            "--input",
+            str(ASSETS_DIR / "sample_benchmarks.json"),
+            "--output",
+            str(out),
+        ]
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    content = out.read_text(encoding="utf-8")
+    assert "# Awesome Bioinformatics Benchmarks" in content
+    assert "### genomics" in content
+
+
+def test_validate_rejects_duplicate_names(tmp_path):
+    bad = {
+        "items": [
+            {
+                "name": "Dup",
+                "task_category": "genomics",
+                "summary": "A",
+                "paper_url": "https://example.com/paper",
+                "code_url": "https://example.com/code",
+                "modality": "sequence",
+                "license": "MIT",
+                "year": 2023,
+            },
+            {
+                "name": "dup",
+                "task_category": "genomics",
+                "summary": "B",
+                "paper_url": "https://example.com/paper2",
+                "code_url": "https://example.com/code2",
+                "modality": "sequence",
+                "license": "MIT",
+                "year": 2024,
+            },
+        ]
+    }
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(bad), encoding="utf-8")
+
+    result = run(
+        [sys.executable, str(SCRIPT_DIR / "validate_benchmarks.py"), "--input", str(path)]
+    )
+    assert result.returncode == 1
+    assert "duplicate name" in result.stdout


### PR DESCRIPTION
### Motivation
- Provide a reusable skill to curate, normalize, validate, and render an awesome-list style catalog of bioinformatics benchmarks from structured metadata.
- Enable deterministic generation and quality checks for benchmark catalogs to enforce consistent schema and link correctness.

### Description
- Added a skill descriptor `bioinformatics-benchmark-curator/SKILL.md` and an `assets/awesome_readme_template.md` as the baseline output structure. 
- Added a sample dataset `assets/sample_benchmarks.json` and a generated sample readme `assets/sample_README.generated.md` to illustrate expected output. 
- Implemented a renderer `scripts/render_awesome_readme.py` that groups by `task_category`, sorts by `year` (descending) then `name`, and emits markdown with canonical links. 
- Implemented a validator `scripts/validate_benchmarks.py` that enforces required fields and types, URL formatting, year range checks, and duplicate-name detection, plus supporting reference docs `references/entry-schema.md` and `references/taxonomy.md`.

### Testing
- Executed the automated test file `tests/test_bioinformatics_benchmark_curator_scripts.py`, which runs the validator and renderer against the sample data and tests duplicate-name rejection. 
- The test suite includes `test_validate_sample_benchmarks_passes`, `test_render_generates_markdown`, and `test_validate_rejects_duplicate_names`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a32e7f4e34832faf2ca116fadd3a67)