### PR TITLE
Add bioinformatics-benchmark-curator toolchain to import, validate, and render benchmark READMEs

### DIFF
--- a/bioinformatics-benchmark-curator/SKILL.md
+++ b/bioinformatics-benchmark-curator/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: bioinformatics-benchmark-curator
+description: Curate, normalize, validate, and generate awesome-list style benchmark pages for bioinformatics (or adjacent scientific ML domains). Use when building or maintaining benchmark catalogs from papers/repos, importing from existing awesome README pages, enforcing a metadata schema, checking links, and rendering grouped Markdown sections.
+---
+
+# Bioinformatics Benchmark Curator
+
+Use this skill to build or maintain benchmark catalogs similar to `awesome-bioinformatics-benchmarks`.
+
+## Workflow
+1. (Optional) Bootstrap JSON from an existing awesome README:
+   - `python scripts/import_from_awesome_readme.py --source <README.md or URL> --output assets/benchmarks.json`
+2. Validate entries:
+   - `python scripts/validate_benchmarks.py --input <path>.json`
+3. Render the catalog page:
+   - `python scripts/render_awesome_readme.py --input <path>.json --output README.generated.md`
+4. Adjust categories and naming conventions with `references/taxonomy.md`.
+
+## Required Fields per Item
+- `name`, `task_category`, `summary`, `paper_url`, `code_url`, `modality`, `license`, `year`
+
+Optional fields:
+- `dataset_url`, `leaderboard_url`, `metrics`, `notes`, `tags`
+
+## Rules
+- URLs must start with `http://` or `https://`.
+- Required string fields must be non-empty.
+- `metrics` and `tags` must be lists of non-empty strings.
+- Duplicate benchmark names (case-insensitive) are rejected.
+- Render order: category ascending, then year descending, then name ascending.
+
+## Resources
+- Schema details: `references/entry-schema.md`
+- Taxonomy guidance: `references/taxonomy.md`
+- Template starter: `assets/awesome_readme_template.md`
+
+
+## Validation & Smoke Tests
+- `pytest -q bioinformatics-benchmark-curator/tests/test_scripts.py`
+- `python bioinformatics-benchmark-curator/scripts/validate_benchmarks.py --input bioinformatics-benchmark-curator/assets/sample_benchmarks.json`

--- a/bioinformatics-benchmark-curator/assets/awesome_readme_template.md
+++ b/bioinformatics-benchmark-curator/assets/awesome_readme_template.md
@@ -1,0 +1,9 @@
+# Awesome Bioinformatics Benchmarks
+
+Curated benchmark resources for bioinformatics and computational biology.
+
+## Contents
+<!-- generated toc -->
+
+## Benchmarks by Category
+<!-- generated sections -->

--- a/bioinformatics-benchmark-curator/assets/imported_from_sample.json
+++ b/bioinformatics-benchmark-curator/assets/imported_from_sample.json
@@ -1,0 +1,26 @@
+{
+  "title": "Awesome Bioinformatics Benchmarks",
+  "description": "Imported benchmark entries from an awesome-style README.",
+  "items": [
+    {
+      "name": "Genome Understanding Evaluation (GUE)",
+      "task_category": "genomics",
+      "summary": "Benchmark suite for genomic sequence understanding tasks.",
+      "paper_url": "https://arxiv.org/abs/2206.11200",
+      "code_url": "https://github.com/ZhiGroup/GUE",
+      "modality": "unknown",
+      "license": "unknown",
+      "year": 2022
+    },
+    {
+      "name": "OpenBioMed-Bench",
+      "task_category": "multimodal-biology",
+      "summary": "Evaluate multimodal biomedical representation learning across tasks.",
+      "paper_url": "https://arxiv.org/abs/2405.00001",
+      "code_url": "https://github.com/PharMolix/OpenBioMed",
+      "modality": "unknown",
+      "license": "unknown",
+      "year": 2024
+    }
+  ]
+}

--- a/bioinformatics-benchmark-curator/assets/sample_README.generated.md
+++ b/bioinformatics-benchmark-curator/assets/sample_README.generated.md
@@ -1,0 +1,15 @@
+# Awesome Bioinformatics Benchmarks
+
+Curated benchmark resources for bioinformatics and computational biology.
+
+## Contents
+- [genomics](#genomics)
+- [multimodal-biology](#multimodal-biology)
+
+## Benchmarks by Category
+
+### genomics
+- **Genome Understanding Evaluation (GUE)** (2022): Benchmark suite for genomic sequence understanding tasks. _(tags: foundation-models, sequence)_ — [paper](https://arxiv.org/abs/2206.11200) | [code](https://github.com/ZhiGroup/GUE)
+
+### multimodal-biology
+- **OpenBioMed-Bench** (2024): Evaluate multimodal biomedical representation learning across tasks. — [paper](https://arxiv.org/abs/2405.00001) | [code](https://github.com/PharMolix/OpenBioMed)

--- a/bioinformatics-benchmark-curator/assets/sample_benchmarks.json
+++ b/bioinformatics-benchmark-curator/assets/sample_benchmarks.json
@@ -1,0 +1,28 @@
+{
+  "title": "Awesome Bioinformatics Benchmarks",
+  "description": "Curated benchmark resources for bioinformatics and computational biology.",
+  "items": [
+    {
+      "name": "Genome Understanding Evaluation (GUE)",
+      "task_category": "genomics",
+      "summary": "Benchmark suite for genomic sequence understanding tasks.",
+      "paper_url": "https://arxiv.org/abs/2206.11200",
+      "code_url": "https://github.com/ZhiGroup/GUE",
+      "modality": "sequence",
+      "license": "MIT",
+      "year": 2022,
+      "tags": ["foundation-models", "sequence"]
+    },
+    {
+      "name": "OpenBioMed-Bench",
+      "task_category": "multimodal-biology",
+      "summary": "Evaluate multimodal biomedical representation learning across tasks.",
+      "paper_url": "https://arxiv.org/abs/2405.00001",
+      "code_url": "https://github.com/PharMolix/OpenBioMed",
+      "modality": "multimodal",
+      "license": "Apache-2.0",
+      "year": 2024,
+      "metrics": ["accuracy", "F1"]
+    }
+  ]
+}

--- a/bioinformatics-benchmark-curator/references/entry-schema.md
+++ b/bioinformatics-benchmark-curator/references/entry-schema.md
@@ -1,0 +1,45 @@
+# Benchmark Entry Schema
+
+## Required Fields
+- `name` (string): Benchmark title.
+- `task_category` (string): Section grouping key.
+- `summary` (string): One-sentence description.
+- `paper_url` (string): Publication/preprint URL.
+- `code_url` (string): Source code URL.
+- `modality` (string): Data modality.
+- `license` (string): Distribution license or `unknown`.
+- `year` (integer): Publication year.
+
+## Optional Fields
+- `dataset_url` (string)
+- `leaderboard_url` (string)
+- `metrics` (array of strings)
+- `tags` (array of strings)
+- `notes` (string)
+
+
+## Validation Constraints
+- Required string fields must be non-empty after trimming.
+- URL fields (`paper_url`, `code_url`, optional `dataset_url`, `leaderboard_url`) must begin with `http://` or `https://`.
+- `year` must be between 1990 and next calendar year.
+- `metrics` and `tags` (when present) must be arrays of non-empty strings.
+- `name` must be unique case-insensitively across all entries.
+
+## Example Entry
+```json
+{
+  "name": "Genomics Long-Range Benchmark",
+  "task_category": "genomics",
+  "summary": "Evaluate sequence models on long-context regulatory prediction tasks.",
+  "paper_url": "https://arxiv.org/abs/2401.00001",
+  "code_url": "https://github.com/example/glrb",
+  "dataset_url": "https://zenodo.org/records/1234567",
+  "leaderboard_url": "https://paperswithcode.com/sota/example",
+  "modality": "sequence",
+  "license": "CC-BY-4.0",
+  "metrics": ["AUROC", "AUPRC"],
+  "tags": ["long-context", "regulatory"],
+  "notes": "Contains train/dev/test splits for human and mouse.",
+  "year": 2024
+}
+```

--- a/bioinformatics-benchmark-curator/references/taxonomy.md
+++ b/bioinformatics-benchmark-curator/references/taxonomy.md
@@ -1,0 +1,21 @@
+# Recommended Taxonomy
+
+Use stable and broad `task_category` values:
+- `genomics`
+- `transcriptomics`
+- `single-cell`
+- `protein-structure`
+- `protein-function`
+- `multimodal-biology`
+- `clinical-omics`
+- `other`
+
+## Naming Guidance
+- Prefer lowercase kebab-case for category keys.
+- Keep category set small; use `tags` for finer granularity.
+- Avoid overlapping categories unless the benchmark is genuinely cross-domain.
+
+## Sort Convention
+Within each category:
+1. `year` descending
+2. `name` ascending

--- a/bioinformatics-benchmark-curator/scripts/import_from_awesome_readme.py
+++ b/bioinformatics-benchmark-curator/scripts/import_from_awesome_readme.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Import benchmark entries from an awesome-list style README."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from urllib.request import urlopen
+
+BULLET_RE = re.compile(r"^-\s+\*\*(?P<name>.+?)\*\*\s*(?P<body>.+)$")
+LINK_RE = re.compile(r"\[(?P<label>[^\]]+)\]\((?P<url>https?://[^)]+)\)")
+YEAR_RE = re.compile(r"\b(19|20)\d{2}\b")
+
+
+def read_text(path_or_url: str) -> str:
+    if path_or_url.startswith("http://") or path_or_url.startswith("https://"):
+        with urlopen(path_or_url) as response:  # nosec: B310 - expected user-provided URL for curated source
+            return response.read().decode("utf-8")
+    return Path(path_or_url).read_text(encoding="utf-8")
+
+
+def normalize_category(heading: str) -> str:
+    cleaned = heading.strip().lower()
+    cleaned = re.sub(r"[^a-z0-9\s-]", "", cleaned)
+    return re.sub(r"\s+", "-", cleaned)
+
+
+def clean_summary(body: str) -> str:
+    no_links = LINK_RE.sub("", body)
+    no_links = re.sub(r"\|", " ", no_links)
+    no_links = re.sub(r"_\(tags:[^)]+\)_", "", no_links)
+    no_links = re.sub(r"\(\d{4}\)", "", no_links)
+    no_links = no_links.replace("—", " ")
+    no_links = re.sub(r"\s+", " ", no_links)
+    return no_links.strip(" :-") or "TBD"
+
+
+def parse_markdown(markdown: str) -> list[dict]:
+    items: list[dict] = []
+    current_category = "uncategorized"
+
+    for raw_line in markdown.splitlines():
+        line = raw_line.strip()
+        if line.startswith("### "):
+            candidate = normalize_category(line[4:])
+            if candidate:
+                current_category = candidate
+            continue
+        if line.startswith("## "):
+            candidate = normalize_category(line[3:])
+            if candidate not in {"contents", "benchmarks-by-category"} and candidate:
+                current_category = candidate
+            continue
+        if not line.startswith("- **"):
+            continue
+
+        match = BULLET_RE.match(line)
+        if not match:
+            continue
+
+        name = match.group("name").strip()
+        body = match.group("body").strip()
+        links = {m.group("label").lower(): m.group("url") for m in LINK_RE.finditer(body)}
+        summary = clean_summary(body)
+
+        year_match = YEAR_RE.search(line)
+        year = int(year_match.group()) if year_match else 2000
+
+        items.append(
+            {
+                "name": name,
+                "task_category": current_category,
+                "summary": summary,
+                "paper_url": links.get("paper", "https://example.com/paper"),
+                "code_url": links.get("code", "https://example.com/code"),
+                "modality": "unknown",
+                "license": "unknown",
+                "year": year,
+            }
+        )
+
+    return items
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source",
+        required=True,
+        help="README markdown URL or local file path (for example raw README.md from awesome-bioinformatics-benchmarks)",
+    )
+    parser.add_argument("--output", required=True, type=Path, help="Path for generated JSON")
+    parser.add_argument("--title", default="Awesome Bioinformatics Benchmarks")
+    parser.add_argument("--description", default="Imported benchmark entries from an awesome-style README.")
+    args = parser.parse_args()
+
+    markdown = read_text(args.source)
+    payload = {
+        "title": args.title,
+        "description": args.description,
+        "items": parse_markdown(markdown),
+    }
+    args.output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"Imported {len(payload['items'])} items into {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bioinformatics-benchmark-curator/scripts/render_awesome_readme.py
+++ b/bioinformatics-benchmark-curator/scripts/render_awesome_readme.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Render an awesome-list style benchmark README from JSON metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def slugify(text: str) -> str:
+    normalized = re.sub(r"[^a-z0-9\s-]", "", text.strip().lower())
+    return re.sub(r"\s+", "-", normalized)
+
+
+def render_item(item: dict) -> str:
+    links = [f"[paper]({item['paper_url']})", f"[code]({item['code_url']})"]
+    if item.get("dataset_url"):
+        links.append(f"[dataset]({item['dataset_url']})")
+    if item.get("leaderboard_url"):
+        links.append(f"[leaderboard]({item['leaderboard_url']})")
+
+    tags = item.get("tags") or []
+    tags_suffix = f" _(tags: {', '.join(sorted(tags))})_" if tags else ""
+
+    tail = f" — {' | '.join(links)}"
+    return f"- **{item['name']}** ({item['year']}): {item['summary']}{tags_suffix}{tail}"
+
+
+def render_markdown(data: dict) -> str:
+    title = data.get("title", "Awesome Bioinformatics Benchmarks")
+    description = data.get("description", "Curated benchmark resources.")
+    items = data.get("items", [])
+
+    grouped = defaultdict(list)
+    for item in items:
+        grouped[item["task_category"]].append(item)
+
+    for category_items in grouped.values():
+        category_items.sort(key=lambda x: (-x["year"], x["name"].lower()))
+
+    categories = sorted(grouped.keys())
+    lines: list[str] = [f"# {title}", "", description, "", "## Contents"]
+    for category in categories:
+        lines.append(f"- [{category}](#{slugify(category)})")
+
+    lines.extend(["", "## Benchmarks by Category", ""])
+    for category in categories:
+        lines.append(f"### {category}")
+        for item in grouped[category]:
+            lines.append(render_item(item))
+        lines.append("")
+
+    return "\n".join(lines).strip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="Path to benchmark JSON")
+    parser.add_argument("--output", required=True, type=Path, help="Output markdown path")
+    args = parser.parse_args()
+
+    data = load_json(args.input)
+    output = render_markdown(data)
+    args.output.write_text(output, encoding="utf-8")
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bioinformatics-benchmark-curator/scripts/validate_benchmarks.py
+++ b/bioinformatics-benchmark-curator/scripts/validate_benchmarks.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Validate benchmark entries for awesome-list style generation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REQUIRED_FIELDS = {
+    "name": str,
+    "task_category": str,
+    "summary": str,
+    "paper_url": str,
+    "code_url": str,
+    "modality": str,
+    "license": str,
+    "year": int,
+}
+URL_FIELDS = {"paper_url", "code_url", "dataset_url", "leaderboard_url"}
+URL_RE = re.compile(r"^https?://")
+LIST_OF_STR_FIELDS = {"metrics", "tags"}
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def validate(data: dict) -> list[str]:
+    errors: list[str] = []
+    items = data.get("items")
+    if not isinstance(items, list):
+        return ["top-level 'items' must be a list"]
+
+    seen_names: set[str] = set()
+    current_year = datetime.now().year + 1
+    for i, item in enumerate(items):
+        if not isinstance(item, dict):
+            errors.append(f"items[{i}] must be an object")
+            continue
+
+        for field, expected_type in REQUIRED_FIELDS.items():
+            if field not in item:
+                errors.append(f"items[{i}] missing required field: {field}")
+                continue
+            if not isinstance(item[field], expected_type):
+                errors.append(
+                    f"items[{i}].{field} must be {expected_type.__name__}, got {type(item[field]).__name__}"
+                )
+                continue
+
+            if expected_type is str and not item[field].strip():
+                errors.append(f"items[{i}].{field} must be a non-empty string")
+
+        name = str(item.get("name", "")).strip().lower()
+        if name:
+            if name in seen_names:
+                errors.append(f"items[{i}] duplicate name: {item.get('name')}")
+            seen_names.add(name)
+
+        year = item.get("year")
+        if isinstance(year, int) and (year < 1990 or year > current_year):
+            errors.append(f"items[{i}].year out of range: {year}")
+
+        for url_field in URL_FIELDS:
+            if url_field in item:
+                value = item.get(url_field)
+                if not isinstance(value, str) or not URL_RE.match(value):
+                    errors.append(f"items[{i}].{url_field} must start with http:// or https://")
+
+        for list_field in LIST_OF_STR_FIELDS:
+            if list_field in item:
+                value = item.get(list_field)
+                if not isinstance(value, list) or any(not isinstance(v, str) or not v.strip() for v in value):
+                    errors.append(f"items[{i}].{list_field} must be a list of non-empty strings")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="Path to benchmark JSON")
+    args = parser.parse_args()
+
+    data = load_json(args.input)
+    errors = validate(data)
+
+    if errors:
+        print("Validation failed:")
+        for err in errors:
+            print(f"- {err}")
+        return 1
+
+    print("Validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bioinformatics-benchmark-curator/tests/test_scripts.py
+++ b/bioinformatics-benchmark-curator/tests/test_scripts.py
@@ -1,0 +1,131 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = ROOT / "bioinformatics-benchmark-curator" / "scripts"
+ASSETS_DIR = ROOT / "bioinformatics-benchmark-curator" / "assets"
+
+
+def run(cmd):
+    return subprocess.run(cmd, text=True, capture_output=True, check=False)
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_validate_sample_benchmarks_passes():
+    result = run(
+        [
+            sys.executable,
+            str(SCRIPT_DIR / "validate_benchmarks.py"),
+            "--input",
+            str(ASSETS_DIR / "sample_benchmarks.json"),
+        ]
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Validation passed" in result.stdout
+
+
+def test_render_generates_markdown(tmp_path):
+    out = tmp_path / "README.generated.md"
+    result = run(
+        [
+            sys.executable,
+            str(SCRIPT_DIR / "render_awesome_readme.py"),
+            "--input",
+            str(ASSETS_DIR / "sample_benchmarks.json"),
+            "--output",
+            str(out),
+        ]
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    content = out.read_text(encoding="utf-8")
+    assert "# Awesome Bioinformatics Benchmarks" in content
+    assert "### genomics" in content
+    assert "tags:" in content
+
+
+def test_validate_rejects_duplicate_names(tmp_path):
+    bad = {
+        "items": [
+            {
+                "name": "Dup",
+                "task_category": "genomics",
+                "summary": "A",
+                "paper_url": "https://example.com/paper",
+                "code_url": "https://example.com/code",
+                "modality": "sequence",
+                "license": "MIT",
+                "year": 2023,
+            },
+            {
+                "name": "dup",
+                "task_category": "genomics",
+                "summary": "B",
+                "paper_url": "https://example.com/paper2",
+                "code_url": "https://example.com/code2",
+                "modality": "sequence",
+                "license": "MIT",
+                "year": 2024,
+            },
+        ]
+    }
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(bad), encoding="utf-8")
+
+    result = run(
+        [sys.executable, str(SCRIPT_DIR / "validate_benchmarks.py"), "--input", str(path)]
+    )
+    assert result.returncode == 1
+    assert "duplicate name" in result.stdout
+
+
+def test_validate_rejects_empty_strings_and_bad_tags(tmp_path):
+    bad = {
+        "items": [
+            {
+                "name": " ",
+                "task_category": "genomics",
+                "summary": "A",
+                "paper_url": "https://example.com/paper",
+                "code_url": "https://example.com/code",
+                "modality": "sequence",
+                "license": "MIT",
+                "year": 2023,
+                "tags": ["ok", ""],
+            }
+        ]
+    }
+    path = tmp_path / "bad_fields.json"
+    path.write_text(json.dumps(bad), encoding="utf-8")
+
+    result = run(
+        [sys.executable, str(SCRIPT_DIR / "validate_benchmarks.py"), "--input", str(path)]
+    )
+    assert result.returncode == 1
+    assert "non-empty string" in result.stdout
+    assert "list of non-empty strings" in result.stdout
+
+
+def test_import_parser_extracts_items():
+    module = _load_module(
+        SCRIPT_DIR / "import_from_awesome_readme.py", "import_from_awesome_readme"
+    )
+    markdown = """
+## Genomics
+- **BenchA**: short summary (2024) — [paper](https://example.com/p) | [code](https://example.com/c)
+"""
+    items = module.parse_markdown(markdown)
+    assert len(items) == 1
+    assert items[0]["name"] == "BenchA"
+    assert items[0]["task_category"] == "genomics"
+    assert items[0]["year"] == 2024


### PR DESCRIPTION
### Motivation
- Provide a small toolchain to curate and maintain awesome-list style benchmark catalogs for bioinformatics and adjacent scientific ML domains.
- Enforce a simple entry schema and validation rules to keep benchmark metadata consistent and machine-readable.
- Allow importing existing awesome-style README files into structured JSON for downstream rendering and editing.
- Ship templates and reference taxonomy to standardize category naming and render order.

### Description
- Add `scripts/import_from_awesome_readme.py` to parse awesome-style READMEs into JSON with normalized categories and extracted links.
- Add `scripts/validate_benchmarks.py` that enforces required fields, URL formats, year range, unique names, and list-of-strings constraints.
- Add `scripts/render_awesome_readme.py` to render a generated README from benchmark JSON with sorted categories and items.
- Add documentation and assets including `references/entry-schema.md`, `references/taxonomy.md`, `assets/awesome_readme_template.md`, sample JSONs, a generated sample README, and `SKILL.md` describing usage.

### Testing
- Ran the test suite with `pytest -q bioinformatics-benchmark-curator/tests/test_scripts.py`, which executes validation on the sample JSON, rendering to markdown, duplicate-name rejection, empty-string/tag checks, and the import parser; the tests passed.
- Individual script behaviors were exercised by tests that invoke `validate_benchmarks.py` and `render_awesome_readme.py` as subprocesses and by directly importing `import_from_awesome_readme.py` for parser unit checks, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a32e7f4e34832faf2ca116fadd3a67)